### PR TITLE
Act like an eval

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -61,7 +61,7 @@ class Sval {
   run(code: string) {
     const ast = parse(code, this.options) as any
     hoist(ast, this.scope)
-    evaluate(ast, this.scope)
+    return evaluate(ast, this.scope)
   }
 }
 


### PR DESCRIPTION
With these updates, sval can really act like eval, returning the value of the passed code, but with the context isolation sval offers.

I think that could be optional, but I think that don't damages anything just acting always as an eval.

```
let res1 = eval("10 * 2");
let res2 = sval.run("10 * 2");
console.log("Eval test 1", res1 === res2);

let res3 = eval("let aj = 123;const aj2 = aj*3;function pepe(asd, asd2) {return asd + asd2;} var cosas = 12; var a = 44; var b = cosas * 2 + a;b");
let res4 = sval.run("let aj = 123;const aj2 = aj*3;function pepe(asd, asd2) {return asd + asd2;} var cosas = 12; var a = 44; var b = cosas * 2 + a;b");
console.log("Eval test 2", res3 === res4);
```