### PR TITLE
sval == actual isolated eval

### DIFF
--- a/src/evaluate/program.ts
+++ b/src/evaluate/program.ts
@@ -3,7 +3,9 @@ import Scope from '../scope'
 import evaluate from '.'
 
 export function* Program(program: estree.Program, scope: Scope) {
+  let ret:any;
   for (let i = 0; i < program.body.length; i++) {
-    yield* evaluate(program.body[i], scope)
+    ret = yield* evaluate(program.body[i], scope)
   }
+  return ret;
 }

--- a/src/evaluate/statement.ts
+++ b/src/evaluate/statement.ts
@@ -6,7 +6,7 @@ import Scope from '../scope'
 import evaluate from '.'
 
 export function* ExpressionStatement(node: estree.ExpressionStatement, scope: Scope) {
-  yield* evaluate(node.expression, scope)
+  return yield* evaluate(node.expression, scope)
 }
 
 export interface BlockOptions {

--- a/src/index.ts
+++ b/src/index.ts
@@ -61,7 +61,7 @@ class Sval {
   run(code: string) {
     const ast = parse(code, this.options) as any
     hoist(ast, this.scope)
-    evaluate(ast, this.scope)
+    return evaluate(ast, this.scope)
   }
 }
 


### PR DESCRIPTION
With these updates, sval can really act like eval, returning the value of the passed code, but with the context isolation sval offers.

I think that could be optional, but I think that don't damages anything just acting always as an eval, just in case someone needs it. If you do not want this, just ignore the `run()` return value.

```
let res1 = eval("10 * 2");
let res2 = sval.run("10 * 2");
console.log("Eval test 1", res1 === res2);

let res3 = eval("let aj = 123;const aj2 = aj*3;function pepe(asd, asd2) {return asd + asd2;} var cosas = 12; var a = 44; var b = cosas * 2 + a;b");
let res4 = sval.run("let aj = 123;const aj2 = aj*3;function pepe(asd, asd2) {return asd + asd2;} var cosas = 12; var a = 44; var b = cosas * 2 + a;b");
console.log("Eval test 2", res3 === res4);
```