### PR TITLE
Define function toString

### DIFF
--- a/src/evaluate/helper.ts
+++ b/src/evaluate/helper.ts
@@ -236,6 +236,14 @@ export function createFunc(
     configurable: true
   })
 
+  const source = node.loc?.source
+  if (source) {
+    define(func, 'toString', {
+      value: () => source.substring(node.start, node.end),
+      configurable: true
+    })
+  }
+
   return func
 }
 


### PR DESCRIPTION
Calling `toString` on a function would return the source code of the interpreter instead of the actual function body as declared.

It's possible to extract the function code from the node itself, using `acorn` options like `sourceFile`.