### PR TITLE
[fix] fix type definitions

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,17 +1,19 @@
 import { Options, Node } from 'acorn';
-export interface SvalOptions {
-    ecmaVer?: Options['ecmaVersion'];
-    sourceType?: Options['sourceType'];
-    sandBox?: boolean;
+declare namespace Sval {
+    interface SvalOptions {
+        ecmaVer?: Options['ecmaVersion'];
+        sourceType?: Options['sourceType'];
+        sandBox?: boolean;
+    }
 }
 declare class Sval {
     static version: string;
     private options;
     private scope;
     exports: Record<string, any>;
-    constructor(options?: SvalOptions);
+    constructor(options?: Sval.SvalOptions);
     import(nameOrModules: string | Record<string, any>, mod?: any): void;
-    parse(code: string, parser?: (code: string, options: SvalOptions) => Node): Node;
+    parse(code: string, parser?: (code: string, options: Sval.SvalOptions) => Node): Node;
     run(code: string | Node): void;
 }
-export default Sval;
+export = Sval;


### PR DESCRIPTION
The build output of this project uses `module.exports = Sval`. The corresponding type definitions are `export = Sval`.

In order to export additional types, a namespace is used.