### PR TITLE
Fix switch statement to handle default clause per ECMAScript spec

### DIFF
--- a/src/evaluate/statement.ts
+++ b/src/evaluate/statement.ts
@@ -146,20 +146,40 @@ export function* IfStatement(node: acorn.IfStatement, scope: Scope, options: Lab
 
 export function* SwitchStatement(node: acorn.SwitchStatement, scope: Scope, options: LabelOptions = {}) {
   const discriminant = yield* evaluate(node.discriminant, scope)
+
+  // Per ECMAScript spec, first check all case clauses for a match,
+  // then fall back to default only if no case matched
   let matched = false
+  let defaultIndex = -1
   for (let i = 0; i < node.cases.length; i++) {
     const eachCase = node.cases[i]
-    if (
+    if (!eachCase.test) {
+      defaultIndex = i
+    } else if (
       !matched
-      && (
-        !eachCase.test  // default
-        || (yield* evaluate(eachCase.test, scope)) === discriminant
-      )
+      && (yield* evaluate(eachCase.test, scope)) === discriminant
     ) {
       matched = true
+      defaultIndex = -1 // a case matched, ignore default
     }
     if (matched) {
       const result = yield* SwitchCase(eachCase, scope)
+      if (result === BREAK) {
+        if (result.LABEL === options.label) {
+          break
+        }
+        return result
+      }
+      if (result === CONTINUE || result === RETURN) {
+        return result
+      }
+    }
+  }
+
+  // No case matched, fall through from default if present
+  if (!matched && defaultIndex !== -1) {
+    for (let i = defaultIndex; i < node.cases.length; i++) {
+      const result = yield* SwitchCase(node.cases[i], scope)
       if (result === BREAK) {
         if (result.LABEL === options.label) {
           break

--- a/tests/statement.test.ts
+++ b/tests/statement.test.ts
@@ -37,6 +37,40 @@ describe('testing statement', () => {
     expect(interpreter.exports.a).toEqual(10)
   })
 
+  it('should switch with default before matching case run normally', () => {
+    const interpreter = new Sval()
+    interpreter.run(`
+      const variant = "secondary"
+      switch (variant) {
+        case "primary":
+        default:
+          exports.a = "primary"
+          break
+        case "secondary":
+          exports.a = "secondary"
+          break
+      }
+    `)
+    expect(interpreter.exports.a).toEqual("secondary")
+  })
+
+  it('should switch fall through from default when no case matches', () => {
+    const interpreter = new Sval()
+    interpreter.run(`
+      switch ("none") {
+        case "a":
+          exports.a = "a"
+          break
+        default:
+          exports.a = "default"
+        case "b":
+          exports.a = "default+b"
+          break
+      }
+    `)
+    expect(interpreter.exports.a).toEqual("default+b")
+  })
+
   it('should for-in statement run normally', () => {
     const interpreter = new Sval()
     interpreter.run(`


### PR DESCRIPTION
## Summary
Fixed the switch statement implementation to correctly handle the `default` clause according to the ECMAScript specification. The interpreter now properly distinguishes between matching a case clause and falling through from the default clause.

## Key Changes
- **Separated case matching from default handling**: The switch statement now first checks all case clauses for a match, then only falls back to the default clause if no case matched
- **Two-phase execution**: 
  - Phase 1: Iterate through all cases to find a match and record the default clause position
  - Phase 2: If no case matched, execute from the default clause onwards
- **Added test coverage**: Two new test cases verify correct behavior:
  - Default clause positioned before a matching case now correctly executes the matching case
  - Default clause with fall-through behavior when no case matches

## Implementation Details
- The `defaultIndex` variable tracks the position of the default clause (identified by `!eachCase.test`)
- When a case matches, `defaultIndex` is reset to `-1` to prevent default execution
- If no case matched and a default exists, execution begins from the default clause and continues through subsequent cases with fall-through semantics
- This ensures proper ECMAScript compliance where the default clause is only entered when no case clause matches

https://claude.ai/code/session_01RNe87LpxantjFCP4KtAunP