### PR TITLE
fix: treat top-level this as undefined in module sourceType (issue #137)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -46,12 +46,14 @@ class Sval {
       this.scope.let('globalThis', win)
       this.scope.let('window', win)
       this.scope.let('self', win)
-      this.scope.let('this', win)
+      // ES modules have undefined as the top-level this (strict mode)
+      this.scope.let('this', sourceType === 'module' ? undefined : win)
     } else {
       this.scope.let('globalThis', globalObj)
       this.scope.let('window', globalObj)
       this.scope.let('self', globalObj)
-      this.scope.let('this', globalObj)
+      // ES modules have undefined as the top-level this (strict mode)
+      this.scope.let('this', sourceType === 'module' ? undefined : globalObj)
     }
 
     this.scope.const(sourceType === 'module' ? EXPORTS : 'exports', this.exports = {})

--- a/tests/function.test.ts
+++ b/tests/function.test.ts
@@ -332,7 +332,16 @@ describe('testing function', () => {
     `)
   })
 
-  it('should serialize functions with toString', () => {  
+  it('should treat function this as undefined in module sourceType (strict mode)', () => {
+    const interpreter = new Sval({ ecmaVer: 11, sandBox: true, sourceType: 'module' })
+    interpreter.run(`
+      var isStrict = (function () { return !this; })();
+      export { isStrict };
+    `)
+    expect(interpreter.exports.isStrict).toBe(true)
+  })
+
+  it('should serialize functions with toString', () => {
     const interpreter = new Sval()
     interpreter.import({ expect })
     const parsedCode = interpreter.parse(`


### PR DESCRIPTION
Per ECMAScript spec, ES modules run in strict mode where the top-level
this is undefined, so non-method function calls have this === undefined
instead of the global object.

https://claude.ai/code/session_01JSyLN9N7fzV71uWNfTGsT2