### PR TITLE
fix: handle null elements in sparse array literals

### DIFF
--- a/src/evaluate/expression.ts
+++ b/src/evaluate/expression.ts
@@ -22,7 +22,9 @@ export function* ArrayExpression(node: acorn.ArrayExpression, scope: Scope) {
   let results: any[] = []
   for (let i = 0; i < node.elements.length; i++) {
     const item = node.elements[i]
-    if (item.type === 'SpreadElement') {
+    if (item === null) {
+      results.length++
+    } else if (item.type === 'SpreadElement') {
       results = results.concat(yield* SpreadElement(item, scope))
     } else {
       results.push(yield* evaluate(item, scope))

--- a/tests/expression.test.ts
+++ b/tests/expression.test.ts
@@ -191,6 +191,25 @@ describe('testing src/expression.ts', () => {
     expect(interpreter.exports.g).toBeInstanceOf(TypeError)
   })
 
+  it('should parse sparse array literals normally', () => {
+    const interpreter = new Sval()
+
+    interpreter.run(`
+      exports.a = [, 1]
+      exports.b = [1, , 2]
+      exports.c = [1, , , 2]
+      exports.d = [,]
+    `)
+
+    expect(interpreter.exports.a).toEqual([, 1])
+    expect(0 in interpreter.exports.a).toBe(false)
+    expect(interpreter.exports.b).toEqual([1, , 2])
+    expect(1 in interpreter.exports.b).toBe(false)
+    expect(interpreter.exports.c).toEqual([1, , , 2])
+    expect(interpreter.exports.d).toEqual([,])
+    expect(interpreter.exports.d.length).toBe(1)
+  })
+
   it('should parse regular expression normally', () => {
     const interpreter = new Sval()
     interpreter.import({ expect })


### PR DESCRIPTION
Sparse arrays like [, 1] or [1, , 2] produce null entries in the AST
elements list per the ESTree spec. Accessing .type on null caused a
TypeError. Now null elements increment results.length to create a proper
array hole, matching native JS behavior.

Fixes #145